### PR TITLE
feat: add CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: make setup
+      - run: make do_openapi_lint || true
+      - run: make provider_mock_prism &
+      - run: sleep 15 && make request
+      - run: make do_openapi2soapui
+      - run: make do_soapui_test
+      - run: docker stop prism
+      - run: make do_generate_consumer
+      - run: make do_consumer_test
+      - run: make do_consumer_pact_verify_openapi
+      - run: make do_generate_provider
+      - run: make do_provider_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
           node-version: '20'
       - run: make setup
       - run: make do_openapi_lint || true
+      - run: OAS_FILE=openapi-fixed.yaml make do_openapi_lint
       - run: make provider_mock_prism &
       - run: sleep 15 && make request
       - run: make do_openapi2soapui

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ### Variables ###
 ##############################
 
-OAS_FILE=openapi/openapi.yaml
+OAS_FILE?=openapi/openapi.yaml
 ENDPOINT?=http://localhost:3001
 HEALTHCHECK_PATH?=http://localhost:3001/products
 PROJECT_FOLDER?=project

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ do_soapui_test: soapui_run ## Run SoapUI test suite
 
 do_generate_consumer: swagger_codegen_cli_fetch swagger_codegen_generators_fetch swagger_codegen_generators_build swagger_codegen_generators_generate consumer_project_install ## Generate consumer project
 do_consumer_test: consumer_project_test ## Test consumer
-do_consumer_pact_verify_openapi: consumer_project_verify_pact_openapi ## Verify consumer with Pact and OpenAPI
+do_consumer_pact_verify_openapi: install_swagger_mock_validator consumer_project_verify_pact_openapi ## Verify consumer with Pact and OpenAPI
 
-do_generate_provider: provider_project_fetch provider_project_install provider_project_run ## Generate provider project
+do_generate_provider: provider_project_fetch provider_project_install ## Generate provider project
 do_provider_test: provider_start_test_stop ## Test provider
 do_provider_verification_pact: provider_project_pact_verification ## Verify provider with Pact
 ##############################
@@ -52,6 +52,7 @@ openapi_fetch: ## Downloads a reference OpenAPI specification
 git_ignore: ## Creates a tailored .gitignore file
 	echo 'swagger-codegen-generators \n\
 	codegen.config.json \n\
+	example-bi-directional-provider-soapui \n\
 	typescript-fetch-pact-consumer \n\
 	openapi2soapui \n\
 	openapi.yaml \n\
@@ -111,7 +112,7 @@ create_spectral_default_ruleset:
 	echo 'extends: ["spectral:oas", "spectral:asyncapi"]' > openapi/.spectral.yaml
 
 openapi_lint_spectral: ## Lints the OpenAPI specification with Spectral
-	docker run --rm --name spectral -it -v ${PWD}/openapi:/openapi stoplight/spectral lint --ruleset "/openapi/.spectral.yaml" "/${OAS_FILE}"
+	docker run --rm --name spectral -v ${PWD}/openapi:/openapi stoplight/spectral lint --ruleset "/openapi/.spectral.yaml" "/${OAS_FILE}"
 
 
 
@@ -138,7 +139,7 @@ swagger_codegen_generators_fetch: ## Get a fork of Swagger-Code-Generators conta
 	git clone -b typescript-fetch-pact https://github.com/smartbear-devrel/swagger-codegen-generators
 
 swagger_codegen_generators_build: ## Build the swagger-codegen-generators project with Java 
-	cd swagger-codegen-generators && mvn package
+	cd swagger-codegen-generators && jenv local 1.8 || echo "jenv not found" && mvn package
 
 swagger_codegen_generators_generate: ## Generate a templated project from a given OpenAPI specification
 	echo '{ "npmName": "typescript-fetch-pact-consumer" }'>codegen.config.json
@@ -151,8 +152,11 @@ consumer_project_install: ## Install the templated project
 consumer_project_test: ## Test the templated project with Pact
 	cd typescript-fetch-pact-consumer && npm test
 
+install_swagger_mock_validator:
+	npm -g install @pactflow/swagger-mock-validator
+
 consumer_project_verify_pact_openapi: ## Verify the templated project with Pact and OpenAPI
-	npx @pactflow/swagger-mock-validator openapi/openapi.yaml typescript-fetch-pact-consumer/pacts/DefaultApi-consumer-DefaultApi.json
+	swagger-mock-validator openapi/openapi.yaml typescript-fetch-pact-consumer/pacts/DefaultApi-consumer-DefaultApi.json
 
 ################################
 ### API Func Testing - SoapUI  ###
@@ -228,7 +232,7 @@ provider_start_test_stop: ## Runs the provider project and tests with SoapUI
 ##############################
 
 sleep:
-	sleep 2
+	sleep 15
 
 docker_stop_all:
 	docker stop $$(docker ps -a -q)


### PR DESCRIPTION
Add a CI workflow that will

- Pull down a sample OpenAPI document
- Lint with Spectral
- Mock with Prism
- Test Mock with SoapUI
- Generate a consumer project with Swagger-Code-Generators
  - Project utilises a modified template to generate Pact consumer contract test
- Runs the consumer project to generate the Pact contracts
- Validates Pact contract against OpenAPI with @pactflow/swagger-mock-validator
- Retrieves a sample provider codebase, developed outside of the OpenAPI document (may suffer from provider drift)
  - Functionally test provider with SoapUI, leverage test suite previously pointed at Prism mock
  - Runs Pact provider verification tests which replay the consumers interactions, against our running provider